### PR TITLE
Fixed index range in updateLeft.m

### DIFF
--- a/Tensor/updateLeft.m
+++ b/Tensor/updateLeft.m
@@ -131,7 +131,7 @@ if ~isempty(X)
             end
         else % (rankC,rankX) = (2,2), (2,3), (3,2)
             T = contract(Cleft,rankC,2,T,rankX+1,rankX);
-            Cleft = contract(B,3,[1 3],T,rankC+rankX-1,[1 rankC],[1 (3:rankC) 2]);
+            Cleft = contract(B,3,[1 3],T,rankC+rankX-1,[1 rankC],[1 (3:rankC+rankX-2) 2]);
         end
     elseif (rankX == 4) && (size(X,1) == 1) % no Cleft, rankX = 4
         % if X is rank-4 and its left leg is dummy, and Cleft is empty (i.e., identity)


### PR DESCRIPTION
Index range should be changed at the line 134 in `Tensor/updateLeft.m`.
If `(rank(C), rank(X)) == (2,3)`, `[1 (3:rankC) 2]` will produce permutation `[1 2]`. (Since `(3:2)` is emtpy)
Therefore, code below will make error

```
[F, Z, S, I] = getLocalSpace('FermionS');
I_connect = getIdentity(I, 2, F, 2, [1 3 2]);
updateLeft(I, 2, I_connect, F, 3, I_connect);

Error using contract (line 109)
ERR: # of indices for the permutation after contraction (= 2) is different from # of legs after contraction (= 3).

Error in updateLeft (line 134)
            Cleft = contract(B, 3, [1 3], T, rankC + rankX - 1, [1 rankC], [1 (3:rankC) 2]);
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

However, replacing `[1 (3:rankC) 2]` with `[1 (3:rankC+rankX-2) 2]` resolves the issue.